### PR TITLE
Use static, dependabot-parseable forms in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/irbrc.gemspec
+++ b/irbrc.gemspec
@@ -1,11 +1,10 @@
 require_relative 'lib/irbrc'
-package = Irbrc
 
 Gem::Specification.new do |s|
-  s.name        = File.basename(__FILE__).split(".")[0]
-  s.version     = package.const_get 'VERSION'
+  s.name        = 'irbrc'
+  s.version     = Irbrc::VERSION
   s.authors     = ['Daniel Pepper']
-  s.summary     = package.to_s
+  s.summary     = 'Irbrc'
   s.description = 'irb rc loader'
   s.homepage    = "https://github.com/dpep/irbrc"
   s.license     = 'MIT'


### PR DESCRIPTION
## Summary

Dependabot's gemspec parser is **static** — it doesn't eval Ruby, it reads the AST and only handles literal `s.name = "string"` and `s.version = SomeConst::VERSION`. The dynamic forms we had defeated that.

When dependabot can't extract the version statically it falls back to `0.0.1` and writes that into `Gemfile.lock`, which then fails CI in frozen mode (gem version mismatch). See dpep/meddleware_rb#18 for the original diagnosis.

This PR switches to the canonical Bundler-scaffold shape:

```ruby
s.name    = "irbrc"
s.version = Irbrc::VERSION
```


## Test plan

- [x] `Bundler.load_gemspec("irbrc.gemspec")` parses statically to name=`irbrc`, version=`0.0.2`
- [x] `bundle install` runs cleanly

## Pattern reference

- dpep/meddleware_rb#18 (diagnosis)
- dpep/amenable_rb#7 (template)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
